### PR TITLE
fixes for replicaSet monitoring

### DIFF
--- a/libmotop/QueryScreen.py
+++ b/libmotop/QueryScreen.py
@@ -119,7 +119,7 @@ class ReplicaSetMemberBlock (ServerBasedBlock):
                         cells.append (member ['lag'])
                     if 'optime' in member:
                         cells.append (member ['optime'])
-                    self.add (cells)
+                    self.__lines.append (cells)
             else:
                 self.hideServer (server)
         Block.reset (self, self.__lines)

--- a/libmotop/Server.py
+++ b/libmotop/Server.py
@@ -152,6 +152,7 @@ class Server:
         else:
             for member in replicaSetStatus ['members']:
                 if 'statusStr' not in member or member ['statusStr'] not in ['ARBITER']:
+                    values = {}
                     values ['set'] = replicaSetStatus ['set']
                     values ['name'] = member ['name']
                     values ['state'] = member ['stateStr']


### PR DESCRIPTION
I've got errors when trying to monitor replicaSet.

First one:

```
Traceback (most recent call last):
  File "/usr/local/bin/motop", line 5, in <module>
    pkg_resources.run_script('motop==2.6', 'motop')
  File "build/bdist.macosx-10.8-intel/egg/pkg_resources.py", line 492, in run_script
  File "build/bdist.macosx-10.8-intel/egg/pkg_resources.py", line 1357, in run_script
    for name in self._index()[zip_path]:
  File "build/bdist.macosx-10.8-intel/egg/pkg_resources.py", line 47, in exec_
    g[name] = val
  File "<string>", line 1, in <module>
  File "/Library/Python/2.7/site-packages/motop-2.6-py2.7.egg/EGG-INFO/scripts/motop", line 4, in <module>
    import pkg_resources
  File "/Library/Python/2.7/site-packages/motop-2.6-py2.7.egg/libmotop/Motop.py", line 106, in __init__
  File "/Library/Python/2.7/site-packages/motop-2.6-py2.7.egg/libmotop/QueryScreen.py", line 258, in action
  File "/Library/Python/2.7/site-packages/motop-2.6-py2.7.egg/libmotop/QueryScreen.py", line 111, in reset
  File "/Library/Python/2.7/site-packages/motop-2.6-py2.7.egg/libmotop/Server.py", line 155, in replicaSetMembers
NameError: global name 'values' is not defined
```

But as soon as I fixed that one another one appeared:

```
Traceback (most recent call last):
  File "/usr/local/bin/motop", line 5, in <module>
    pkg_resources.run_script('motop==2.4', 'motop')
  File "build/bdist.macosx-10.8-intel/egg/pkg_resources.py", line 492, in run_script
  File "build/bdist.macosx-10.8-intel/egg/pkg_resources.py", line 1357, in run_script
    for name in self._index()[zip_path]:
  File "build/bdist.macosx-10.8-intel/egg/pkg_resources.py", line 47, in exec_
    g[name] = val
  File "<string>", line 1, in <module>
  File "/Library/Python/2.7/site-packages/motop-2.4-py2.7.egg/EGG-INFO/scripts/motop", line 4, in <module>
    import pkg_resources
  File "build/bdist.macosx-10.8-intel/egg/libmotop/Motop.py", line 106, in __init__
  File "build/bdist.macosx-10.8-intel/egg/libmotop/QueryScreen.py", line 258, in action
  File "build/bdist.macosx-10.8-intel/egg/libmotop/QueryScreen.py", line 122, in reset
AttributeError: ReplicaSetMemberBlock instance has no attribute 'add'
```

So I made fix for that too.
