### PR TITLE
make motop installable via pip

### DIFF
--- a/libmotop/__init__.py
+++ b/libmotop/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+##
+# motop - Unix "top" Clone for MongoDB
+#
+# Copyright (c) 2012, Tart İnternet Teknolojileri Ticaret AŞ
+#
+# Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby
+# granted, provided that the above copyright notice and this permission notice appear in all copies.
+#
+# The software is provided "as is" and the author disclaims all warranties with regard to the software including all
+# implied warranties of merchantability and fitness. In no event shall the author be liable for any special, direct,
+# indirect, or consequential damages or any damages whatsoever resulting from loss of use, data or profits, whether
+# in an action of contract, negligence or other tortious action, arising out of or in connection with the use or
+# performance of this software.
+##
+
+__name__ = 'motop'
+__version__ = 4.1
+__doc__ = '"Top" clone for MongoDB.'

--- a/libmotop/motop.py
+++ b/libmotop/motop.py
@@ -27,9 +27,7 @@ except ImportError:
     from configparser import SafeConfigParser
 
 """Metadata"""
-__name__ = 'motop'
-__version__ = 4.1
-__doc__ = '"Top" clone for MongoDB.'
+from libmotop import __name__, __version__, __doc__
 
 """Main configuration"""
 configFile = '/etc/motop.conf'

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python
 
 from setuptools import setup
-from libmotop import motop
+import libmotop
 
 def readme():
     with open('README.rst') as readmeFile:
         return readmeFile.read()
 
-setup(name=motop.__name__,
-        version=str(motop.__version__),
+setup(name=libmotop.__name__,
+        version=str(libmotop.__version__),
         packages=('libmotop',),
         scripts=('motop',),
         install_requires=('pymongo', 'argparse'),
@@ -17,7 +17,7 @@ setup(name=motop.__name__,
         license='ICS',
         url='https://github.com/tart/motop',
         platforms='POSIX',
-        description=motop.__doc__,
+        description=libmotop.__doc__,
         keywords='mongo realtime monitoring examine explain kill operations',
         long_description=readme())
 


### PR DESCRIPTION
`from libmotop import motop` in setup.py imports libmotop.server, which needs
pymongo, so there is circular dependency when installing motop via pip, this
commit fixes it.
